### PR TITLE
Upgrade to metricq version 2.0

### DIFF
--- a/metricq_source_snmp/main.py
+++ b/metricq_source_snmp/main.py
@@ -125,7 +125,7 @@ class SnmpSource(metricq.IntervalSource):
     @metricq.rpc_handler('config')
     async def _on_config(self, default_community, default_interval, default_prefix, default_object_collections,
                          additional_metric_attributes, snmp_object_collections, **config):
-        self.period = 1
+        self.period = metricq.Timedelta.from_s(1)
         metrics = {}  # holds metrics for declaration to metricq
 
         # key: ip, data: [(OID, metric-name, multi, interval), ...]

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(name='metricq_source_snmp',
       entry_points='''
       [console_scripts]
       metricq-source-snmp=metricq_source_snmp:run
-      ''',
-      install_requires=['aiomonitor', 'click', 'click_log', 'metricq', 'pysnmp'])
+      """,
+    install_requires=["aiomonitor", "click", "click_log", "metricq ~= 2.0", "pysnmp"],
+)


### PR DESCRIPTION
`IntervalSource.period` is now a Timedelta; explicitly set a source period of 1 second.

Other than that, there seem to be no breaking changes that affect this source.  Full upgrading instruction can be found [here](https://metricq.github.io/metricq-python/upgrading.html#x-2-0), in case I missed something.